### PR TITLE
User can receive and send messages

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -6,8 +6,12 @@ class ConversationsController < ApplicationController
 
   def create
     recipients = User.where(id: conversation_params[:recipients])
+    
     conversation = current_user.send_message(recipients, conversation_params[:body], conversation_params[:subject]).conversation
+    
     flash[:success] = 'Your message was successfully sent!'
+    
+    
     redirect_to conversation_path(conversation)
   end
 

--- a/app/views/mailbox/_folder_view.html.erb
+++ b/app/views/mailbox/_folder_view.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="spacer"></div>
   <div class="col-md-12">
-    <!-- we'll configure this to compose new conversations later -->
+    <!-- well configure this to compose new conversations later -->
     <%= link_to "Compose", new_conversation_path, class: "btn btn-success" %>
     <div class="spacer"></div>
   </div>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { "MyName" }
+    email { "Email@email.com" }
+    password { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name { "MyName" }
-    email { "Email@email.com" }
-    password { "MyString" }
+    name { "Michael#{rand(0..99)}" }
+    email { "someone#{rand(0..99)}@mail.com" }
+    password { "password" }
   end
 end

--- a/spec/features/user_can_receive_and_send_messages_spec.rb
+++ b/spec/features/user_can_receive_and_send_messages_spec.rb
@@ -1,0 +1,26 @@
+feature 'User can receive a message' do 
+    
+        let(:user) { FactoryBot.create(:user )}
+        before do 
+            login_as(user, scope: :user)
+            visit root_path
+        end
+
+        let(:poster) { FactoryBot.create(:user, email: 'poster@mail.com')}
+        let(:receiver) { FactoryBot.create(:user, email: 'receiver@mail.com')}
+        before do
+            poster.send_message(receiver, 'Hello receiver!', 'Hi there')
+
+        end
+
+
+  
+    describe 'User can send a message' do
+        it 'User should see sucess message' do
+            expect(page).to have_content 'Your message was successfully sent'
+        end
+    end
+
+
+
+end

--- a/spec/features/user_can_receive_and_send_messages_spec.rb
+++ b/spec/features/user_can_receive_and_send_messages_spec.rb
@@ -4,22 +4,20 @@ feature 'User can receive a message' do
         before do 
             login_as(user, scope: :user)
             visit root_path
-        end
-
-        let(:poster) { FactoryBot.create(:user, email: 'poster@mail.com')}
-        let(:receiver) { FactoryBot.create(:user, email: 'receiver@mail.com')}
-        before do
-            poster.send_message(receiver, 'Hello receiver!', 'Hi there')
+            user.send_message(user, 'Hello receiver!', 'Hi there')
 
         end
 
 
   
     describe 'User can send a message' do
-        it 'User should see sucess message' do
-            expect(page).to have_content 'Your message was successfully sent'
+        it 'User should see success message' do
+            expect(page).to have_content 'Your message was successfully sent!'
+            
         end
     end
+
+    
 
 
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
+  config.include Warden::Test::Helpers 
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
We have worked in this branch starting with the usage of a Factory bot model user to create the person who logs in and sends the message.
To pass the authentication layer we used the Warden helper.
After that we created the following block:
    ```
 it 'User should see success message' do
            expect(page).to have_content 'Your message was successfully `sent!'`
            
        end
```
We had a tricky error to solve with this implementation since the path was following the nav bar (Failure/error: Toggle navigation CA Mailboxer\nHello, Michael18 Inbox Logout\nCraft Academy Mailboxer)
Even though we tried to redirect the path in different ways to get a different output, it didn’t work.
We asked for help from Noel and we are going to have a look again later.